### PR TITLE
chore: Bumps source commit and go version

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,9 +14,9 @@ parts:
     plugin: go
     source: https://github.com/omec-project/nrf.git
     source-type: git
-    source-commit: b747b98520a4c154f5cf1fcf7b2b1bec2600c7cc
+    source-commit: 242879c6405bdce762d808f0589666d35236c035
     build-snaps:
-      - go/1.18/stable
+      - go/1.21/stable
     stage-packages:
       - libc6_libs
     organize:


### PR DESCRIPTION
# Description

As we bumped to go version to 1.21 in the upstream project and made many dependency updates there, we bump the commit to the latest one available in the upstream project that contains all those changes.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
