### PR TITLE
chore: Bump NRF commit ID to get latest changes

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/nrf.git
     source-type: git
-    source-commit: 242879c6405bdce762d808f0589666d35236c035
+    source-commit: 4d4c57f4fb1594688046fde158800cbc49d7f545
     build-snaps:
       - go/1.21/stable
     stage-packages:


### PR DESCRIPTION
# Description

Bumps the commit ID of the upstream project to fetch latest changes, including many dependencies update for security and a fix for the 100% CPU usage when the network is not configured.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
