### PR TITLE
chore: Bumps project version to 1.6.0 after branching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,17 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "chore: "
+
+  - package-ecosystem: "github-actions"
+    target-branch: v1.5.2
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore: "
+    groups:
+      github_actions:
+        patterns:
+          - "*"
+    labels:
+      - v1.5.2

--- a/.github/workflows/1_5_2_scheduled_runs.yaml
+++ b/.github/workflows/1_5_2_scheduled_runs.yaml
@@ -1,10 +1,6 @@
-name: Main
+name: Release v1.5.2 scheduled CI
 
 on:
-  pull_request:
-    branches:
-      - main
-  push:
   schedule:
     - cron: '0 0 * * 0'
 
@@ -12,12 +8,11 @@ jobs:
 
   build-rock:
     uses: canonical/sdcore-github-workflows/.github/workflows/build-rock.yaml@v2.3.0
+    with:
+      branch-name: "v1.5.2"
 
   scan-rock:
     needs: build-rock
     uses: canonical/sdcore-github-workflows/.github/workflows/scan-rock.yaml@v2.3.0
-
-  publish-rock:
-    if: github.ref_name == 'main'
-    needs: scan-rock
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-rock.yaml@v2.3.0
+    with:
+      branch-name: "v1.5.2"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Container image for SD-Core NRF.
 ## Usage
 
 ```console
-docker pull ghcr.io/canonical/sdcore-nrf:1.4.0
-docker run -it ghcr.io/canonical/sdcore-nrf:1.4.0
+docker pull ghcr.io/canonical/sdcore-nrf:1.6.0
+docker run -it ghcr.io/canonical/sdcore-nrf:1.6.0
 ```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: sdcore-nrf
 base: bare
 build-base: ubuntu@24.04
-version: '1.5.2'
+version: '1.6.0'
 summary: SD-Core NRF
 description: SD-Core NRF
 license: Apache-2.0


### PR DESCRIPTION
# Description

Bumps project version to `1.6.0` after branching

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
