### PR TITLE
fix: Remove duplicate CI jobs in PR branches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - v1.5.2
   push:
+    branches:
+      - v1.5.2
 
 jobs:
 


### PR DESCRIPTION
# Description

This prevents duplicate CI jobs from running in PR branches, while allowing the CI to run when PRs are merged to the release branch.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
